### PR TITLE
Make machine token client constructor protected

### DIFF
--- a/services/client/MachineTokenClient.ts
+++ b/services/client/MachineTokenClient.ts
@@ -5,9 +5,9 @@ import OAuthClient from './OAuthClient'
 
 class MachineTokenClient {
   public constructor(
-    private readonly appClientSecretName: string,
-    private readonly secretsClient: SecretsClient,
-    private readonly oAuthClient: OAuthClient,
+    protected readonly appClientSecretName: string,
+    protected readonly secretsClient: SecretsClient,
+    protected readonly oAuthClient: OAuthClient,
   ) {}
 
   public async getMachineToken(): Promise<string> {


### PR DESCRIPTION
Want to: 
- Extend the machine token client for OAuth flows that do not support client_credentials