### PR TITLE
Feature: Make MachineTokenClient constructor protected and symbolize both the MachineClient and MachineTokenClient for core services

### DIFF
--- a/providers/core-services.ts
+++ b/providers/core-services.ts
@@ -12,11 +12,13 @@ import awsProvider from './aws'
 import utilsProvider, { HttpClient } from './utils'
 import { JSONSerializer } from '../utils/serialization'
 
-
 export const coreServicesMachineTokenClient =
   ServiceProvider.createSymbol<MachineTokenClient>(
     'CoreServicesMachineTokenClient',
   )
+
+export const coreServicesMachineClient =
+  ServiceProvider.createSymbol<MachineClient>('CoreServicesMachineClient')
 
 const configureCoreServices = (
   baseUrl: string,
@@ -43,7 +45,7 @@ const configureCoreServices = (
   )
 
   coreServicesProvider.register(
-    MachineClient,
+    coreServicesMachineClient,
     Lifecycle.Singleton,
     () =>
       new MachineClient(

--- a/providers/core-services.ts
+++ b/providers/core-services.ts
@@ -10,11 +10,17 @@ import SecretsClient from '../services/aws/SecretsClient'
 
 import awsProvider from './aws'
 import utilsProvider, { HttpClient } from './utils'
-import {JSONSerializer} from '../utils/serialization'
+import { JSONSerializer } from '../utils/serialization'
+
+
+export const coreServicesMachineTokenClient =
+  ServiceProvider.createSymbol<MachineTokenClient>(
+    'CoreServicesMachineTokenClient',
+  )
 
 const configureCoreServices = (
   baseUrl: string,
-  clientSecretName: string
+  clientSecretName: string,
 ): ServiceProvider => {
   const coreServicesProvider = new ServiceProvider()
 
@@ -25,7 +31,7 @@ const configureCoreServices = (
   )
 
   coreServicesProvider.register(
-    MachineTokenClient,
+    coreServicesMachineTokenClient,
     Lifecycle.Singleton,
     () =>
       new MachineTokenClient(
@@ -41,7 +47,7 @@ const configureCoreServices = (
     Lifecycle.Singleton,
     () =>
       new MachineClient(
-        coreServicesProvider.provide(MachineTokenClient),
+        coreServicesProvider.provide(coreServicesMachineTokenClient),
         utilsProvider.provide(HttpClient),
         utilsProvider.provide(MemoryCache),
         'core-services-token',

--- a/providers/utils.ts
+++ b/providers/utils.ts
@@ -11,8 +11,10 @@ import { HttpClient as GenericHttpClient } from '../services/client/HttpClient'
 import AxiosClient from '../services/client/AxiosClient'
 
 export const Logger = ServiceProvider.createSymbol<GenericLogger>('Logger')
-export const Serializer = ServiceProvider.createSymbol<GenericSerializer>('Serializer')
-export const HttpClient = ServiceProvider.createSymbol<GenericHttpClient>('HttpClient')
+export const Serializer =
+  ServiceProvider.createSymbol<GenericSerializer>('Serializer')
+export const HttpClient =
+  ServiceProvider.createSymbol<GenericHttpClient>('HttpClient')
 
 const utilsProvider = new ServiceProvider()
 

--- a/services/client/MachineTokenClient/index.ts
+++ b/services/client/MachineTokenClient/index.ts
@@ -11,10 +11,10 @@ export { default as TokenNotFoundError } from './TokenNotFoundError'
 
 class MachineTokenClient {
   public constructor(
-    private readonly appClientSecretName: string,
-    private readonly secretsClient: SecretsClient,
-    private readonly oAuthClient: OAuthClient,
-    private readonly serializer: JSONSerializer,
+    protected readonly appClientSecretName: string,
+    protected readonly secretsClient: SecretsClient,
+    protected readonly oAuthClient: OAuthClient,
+    protected readonly serializer: JSONSerializer,
   ) {}
 
   public async getMachineToken(): Promise<string> {


### PR DESCRIPTION
Rectifies a problem when merging: https://github.com/Trunkrs/common/commit/2565420fe57c45d82b35aa0e8f394c1deefddea0

where the MachineTokenClient was made private again.

Also, this PR exports a symbolized version of the core services MachineClient and MachineTokenClient to set them apart from other implementations