### PR TITLE
Hotfix: Make MemoryCache generic

### DIFF
--- a/providers/aws.ts
+++ b/providers/aws.ts
@@ -1,9 +1,8 @@
 import ServiceProvider, { Lifecycle } from '../utils/service-provider'
 
 import SecretsClient from '../services/aws/SecretsClient'
-import { MemoryCache } from '../utils/caching'
 
-import utilsProvider from './utils'
+import utilsProvider, { MemoryCache } from './utils'
 
 const awsProvider = new ServiceProvider()
 

--- a/providers/core-services.ts
+++ b/providers/core-services.ts
@@ -1,5 +1,4 @@
 import ServiceProvider, { Lifecycle } from '../utils/service-provider'
-import { MemoryCache } from '../utils/caching'
 
 import {
   CognitoOAuthClient,
@@ -9,7 +8,7 @@ import {
 import SecretsClient from '../services/aws/SecretsClient'
 
 import awsProvider from './aws'
-import utilsProvider, { Serializer, HttpClient } from './utils'
+import utilsProvider, { Serializer, HttpClient, MemoryCache } from './utils'
 
 export const coreServicesMachineTokenClient =
   ServiceProvider.createSymbol<MachineTokenClient>(

--- a/providers/utils.ts
+++ b/providers/utils.ts
@@ -5,7 +5,7 @@ import {
   JSONSerializer,
   Serializer as GenericSerializer,
 } from '../utils/serialization'
-import { MemoryCache } from '../utils/caching'
+import { MemoryCache as GenericMemoryCache } from '../utils/caching'
 
 import { HttpClient as GenericHttpClient } from '../services/client/HttpClient'
 import AxiosClient from '../services/client/AxiosClient'
@@ -14,12 +14,16 @@ import { OAuthClient } from '../services/client'
 export const Logger = ServiceProvider.createSymbol<GenericLogger>('Logger')
 export const Serializer =
   ServiceProvider.createSymbol<GenericSerializer>('Serializer')
+
 export const HttpClient =
   ServiceProvider.createSymbol<GenericHttpClient>('HttpClient')
 
+export const MemoryCache =
+  ServiceProvider.createSymbol<GenericMemoryCache>('MemoryCache')
+
 const utilsProvider = new ServiceProvider()
 
-utilsProvider.register(HttpClient, Lifecycle.Singleton, () => new AxiosClient())
+utilsProvider.register(HttpClient, Lifecycle.Transient, () => new AxiosClient())
 
 utilsProvider.register(Logger, Lifecycle.Singleton, () => new ConsoleLogger())
 


### PR DESCRIPTION
This may have been the reason I've been having trouble extending this and adding a staleness timeout to the new instance. MemoryCache is now given a generic symbol for it's own instance, like the other utilities
