### PR TITLE
Implement: SNS Publish Batch (bumps aws-sdk => 2.1067.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.92",
     "@types/faker": "^5.5.8",
     "@types/jest": "^27.0.1",
     "@types/joi": "^17.2.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Leonard Breitkopf <leonard@trunkrs.nl>",
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "^2.952.0",
+    "aws-sdk": "^2.1067.0",
     "axios": "^0.21.4",
     "date-fns": "^2.25.0",
     "deepmerge": "^4.2.2",
@@ -17,7 +17,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.83",
     "@types/faker": "^5.5.8",
     "@types/jest": "^27.0.1",
     "@types/joi": "^17.2.3",
@@ -47,7 +46,7 @@
     "peer": {
       "@typescript-eslint/eslint-plugin": ">=4 || <5",
       "@typescript-eslint/parser": ">=4 || <5",
-      "aws-sdk": ">2.900.0 || <3",
+      "aws-sdk": ">2.1067.0 || <3",
       "date-fns": ">=2 || <3",
       "eslint": ">=7.2.0",
       "eslint-config-airbnb-base-typescript-prettier": ">=3.1 || <4",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "peer": {
       "@typescript-eslint/eslint-plugin": ">=4 || <5",
       "@typescript-eslint/parser": ">=4 || <5",
-      "aws-sdk": ">2.1067.0 || <3",
+      "aws-sdk": ">2.1000.0 || <3",
       "date-fns": ">=2 || <3",
       "eslint": ">=7.2.0",
       "eslint-config-airbnb-base-typescript-prettier": ">=3.1 || <4",

--- a/services/queue/QueueClient/models.ts
+++ b/services/queue/QueueClient/models.ts
@@ -6,6 +6,7 @@ export interface SQSMessageOptions {
 export interface SNSMessageOptions {
   deduplicationId?: string
   messageGroupId?: string
+  messageDeduplicationId?: string
   attributes?: { [key: string]: string | number | boolean }
 }
 

--- a/services/queue/SNSQueueClient.ts
+++ b/services/queue/SNSQueueClient.ts
@@ -69,7 +69,7 @@ class SNSQueueClient implements QueueClient {
         TopicArn: this.topicArn,
         Message: this.serializer.serialize(request.message, 'string'),
         MessageGroupId: request.options?.messageGroupId,
-        MessageDeduplicationId: request.options?.messageGroupId,
+        MessageDeduplicationId: request.options?.messageDeduplicationId,
         MessageAttributes: attributes,
       })
       .promise()
@@ -88,7 +88,7 @@ class SNSQueueClient implements QueueClient {
       Id: uuidV1(),
       Message: this.serializer.serialize(message, 'string'),
       MessageGroupId: request.options?.messageGroupId,
-      MessageDeduplicationId: request.options?.messageGroupId,
+      MessageDeduplicationId: request.options?.messageDeduplicationId,
       MessageAttributes: attributes,
     }))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,6 +606,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@types/aws-lambda@^8.10.92":
+  version "8.10.92"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.92.tgz#645f769ff88b8eba1acd35542695ac322c7757c4"
+  integrity sha512-dB14TltT1SNq73z3MaZfKyyBZ37NAgAFl8jze59bisR4fJ6pB6AYGxItHFkooZbN7UcVJX/cFudM4p8wp1W4rA==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.16"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.16.tgz#bc12c74b7d65e82d29876b5d0baf5c625ac58702"

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,11 +606,6 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@types/aws-lambda@^8.10.83":
-  version "8.10.83"
-  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.83.tgz#66db06cedb7476e860e8655e4387fd2e4385433a"
-  integrity sha512-7YsLv/B8rF7K7jYAGmYBxLq3QU+hQV7qNJBMcSCmJCTcXuzoTKGBX8d4v9CsVs0SOKBSAErXG7rtk8jVxiP30g==
-
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.16"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.16.tgz#bc12c74b7d65e82d29876b5d0baf5c625ac58702"
@@ -1074,7 +1069,7 @@ aws-lambda@^1.0.6:
     js-yaml "^3.13.1"
     watchpack "^2.0.0-beta.10"
 
-aws-sdk@*, aws-sdk@^2.952.0:
+aws-sdk@*:
   version "2.1000.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1000.0.tgz#408e02dd299541b9e35c85244df9df51cbb2f76a"
   integrity sha512-PhL4WPIJ5fyOBbmWdEaskD6+qvu9VD4kVLEBK/SchcZXmivUKhED3POR6dbfskhwTksxwkrwa6G4NNI3yY7d1g==
@@ -1083,6 +1078,21 @@ aws-sdk@*, aws-sdk@^2.952.0:
     events "1.1.1"
     ieee754 "1.1.13"
     jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
+aws-sdk@^2.1067.0:
+  version "2.1067.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1067.0.tgz#2e7f5a2d765fcf77a45f25fdd1f12a64942628a7"
+  integrity sha512-3Ys1k4cNQy4z37IpPjQ9c5ldkXMeZGbWoarKHynPPY3WCEj+Nw2u6zk484fA9/lTHNN3YesLuZ0OmEzGgjFEOw==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.16.0"
     querystring "0.2.0"
     sax "1.2.1"
     url "0.10.3"
@@ -2937,6 +2947,11 @@ jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
+
+jmespath@0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
+  integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
 joi@*, joi@^17.4.2:
   version "17.4.2"


### PR DESCRIPTION
Upgrades the SNSQueueClient sendBatchMessage implementation to accommodate AWS SDK's new `publishBatch()` feature for SNS