### PR TITLE
Hotfix: Polyfill publishBatch for the SNS Queue Client

### DIFF
--- a/services/queue/SNSQueueClient.ts
+++ b/services/queue/SNSQueueClient.ts
@@ -42,7 +42,7 @@ class SNSQueueClient implements QueueClient {
     )
   }
 
-  private readonly client = new SNS({ apiVersion: '' })
+  private readonly client = new SNS()
 
   constructor(
     /**


### PR DESCRIPTION
As of writing, AWS Lambda does not support `SNS.publishBatch`. This PR aims to introduce support to older versions of SNS for the `SNSQueueClient`

https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
