### PR TITLE
Hotfix: SNSQueueClient - Missing escape instruction

### DIFF
--- a/services/queue/SNSQueueClient.ts
+++ b/services/queue/SNSQueueClient.ts
@@ -85,6 +85,8 @@ class SNSQueueClient implements QueueClient {
       )
 
       await Promise.all(batchSendMessagePromises)
+
+      return
     }
 
     const attributes = request.options?.attributes


### PR DESCRIPTION
Fixes a small bug where `SNSQueueClient.sendBatchMessage` doesn't escape properly if `publishBatch` does not exist