### PR TITLE
hotfix: undefined where parameters on scan operation

### DIFF
--- a/services/aws/dynamodb/errors/WhereClauseNotProvidedError.ts
+++ b/services/aws/dynamodb/errors/WhereClauseNotProvidedError.ts
@@ -1,0 +1,11 @@
+import ErrorBase from '../../../../models/errors/ErrorBase'
+
+class WhereClauseNotProvidedError extends ErrorBase {
+  public constructor() {
+    super()
+
+    this.message = 'A where clause must be provided for this DynamoDB operation'
+  }
+}
+
+export default WhereClauseNotProvidedError

--- a/services/aws/dynamodb/utils/query/QueryParameters.ts
+++ b/services/aws/dynamodb/utils/query/QueryParameters.ts
@@ -4,7 +4,7 @@ interface QueryParameters<TEntity> {
   queryOptions?: {
     operation?: 'Scan' | 'Query'
   }
-  where: WhereParameters<TEntity>
+  where?: WhereParameters<TEntity>
   select?: Array<keyof TEntity>
   limit?: number
   orderDescending?: boolean


### PR DESCRIPTION
fixes:

```
{
  "errorType": "ValidationException",
  "errorMessage": "ExpressionAttributeValues can only be specified when using expressions: FilterExpression is null",
}
```